### PR TITLE
[DPE-4845] Bump version of Spark8t library

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -42,7 +42,7 @@ parts:
       - python3-pip
     overlay-script: |
       mkdir -p $CRAFT_PART_INSTALL/opt/spark8t/python/dist
-      pip install --target=${CRAFT_PART_INSTALL}/opt/spark8t/python/dist  https://github.com/canonical/spark-k8s-toolkit-py/releases/download/v0.0.7/spark8t-0.0.7-py3-none-any.whl
+      pip install --target=${CRAFT_PART_INSTALL}/opt/spark8t/python/dist  https://github.com/canonical/spark-k8s-toolkit-py/releases/download/v0.0.10/spark8t-0.0.10-py3-none-any.whl
       rm usr/bin/pip*
     stage:
       - opt/spark8t/python/dist


### PR DESCRIPTION
We need to bump this in order to use the new feature in Spark8t which creates non existing namespaces when a account is created.