### PR TITLE
[MISC] Use auto-populated secrets.GITHUB_TOKEN in place of secrets.GHCR_TOKEN

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -75,7 +75,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: unused # Required input—but not used
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Import and push to GHCR

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -75,8 +75,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USER }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: unused # Required input—but not used
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Import and push to GHCR
         run: |


### PR DESCRIPTION
Ref: https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/release_rock.yaml#L51
Github Documentation: https://docs.github.com/en/actions/concepts/security/github_token#about-the-github_token