### PR TITLE
[PRA-30] Restrict secret creation to allowlist

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,22 @@ jobs:
         run:  |
           yamllint -d "{extends: relaxed, rules: {line-length: {max: 250}}}" \
             --no-warnings rockcraft.yaml
+      - name: Install tox
+        run: pipx install tox
+      - name: Run linters
+        run: tox run -e lint
+
+  unit-test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Install tox
+        run: pipx install tox
+      - name: Run tests
+        run: tox run -e unit
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,18 +8,17 @@ on:
         description: "The rock output of build process."
         value: ${{ jobs.build.outputs.rock }}
 
-
 jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install yamllint
         run: python3 -m pip install yamllint
       - name: YAML Lint
-        run:  |
+        run: |
           yamllint -d "{extends: relaxed, rules: {line-length: {max: 250}}}" \
             --no-warnings rockcraft.yaml
       - name: Install tox
@@ -46,7 +45,7 @@ jobs:
       - lint
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup LXD
         uses: canonical/setup-lxd@main
@@ -56,7 +55,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap install yq
-          sudo snap install rockcraft --classic    
+          sudo snap install rockcraft --classic
           sudo snap install --devmode --channel edge skopeo
 
       - name: Build image
@@ -70,9 +69,9 @@ jobs:
         run: sudo chmod a+r ${{ steps.build.outputs.name }}
 
       - name: Upload locally built artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: spark-integration-hub
-          path:  ${{ steps.build.outputs.name }}
+          path: ${{ steps.build.outputs.name }}
     outputs:
       rock: ${{ steps.build.outputs.name }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,15 +2,14 @@ name: Publish rock
 on:
   push:
     branches:
-      - '3/*'
+      - "3/*"
 
 jobs:
-
   release_checks:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Extract branch metadata
         shell: bash
@@ -57,7 +56,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install rockcraft
         run: |
@@ -97,19 +96,19 @@ jobs:
           echo "1"
           COMMIT_ID=$(git log -1 --format=%H)
           DESCRIPTION=$(yq .description rockcraft.yaml | xargs)
-          
+
           # Add relevant labels
           echo "FROM ${IMAGE_NAME}:${TAG}" | docker build --label org.opencontainers.image.description="${DESCRIPTION}" --label org.opencontainers.image.revision="${COMMIT_ID}" --label org.opencontainers.image.source="${{ github.repositoryUrl }}" -t "${IMAGE_NAME}:${TAG}" -
           echo "2"
-          echo "Publishing ${IMAGE_NAME}:${TAG}"          
+          echo "Publishing ${IMAGE_NAME}:${TAG}"
           docker push ${IMAGE_NAME}:${TAG}
-          
-          if [[ "$RISK" == "edge" ]]; then           
+
+          if [[ "$RISK" == "edge" ]]; then
             VERSION_TAG="${{ needs.release_checks.outputs.version }}-${{ needs.release_checks.outputs.base }}_edge"
-            
+
             docker tag ${IMAGE_NAME}:${TAG} ${IMAGE_NAME}:${VERSION_TAG}
-            
-            echo "Publishing ${IMAGE_NAME}:${VERSION_TAG}"          
+
+            echo "Publishing ${IMAGE_NAME}:${VERSION_TAG}"
             docker push ${IMAGE_NAME}:${VERSION_TAG}
           fi
           echo "3"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+
 *.rock

--- a/files/bin/monitor_sa.sh
+++ b/files/bin/monitor_sa.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
-python3 -m opt.hub.scripts.monitor_sa --app-name=integration-hub --config=${SPARK_PROPERTIES_FILE} --timeout=30
+python3 -m opt.hub.scripts.monitor_sa \
+--app-name=integration-hub \
+--config=${SPARK_PROPERTIES_FILE} \
+--allowlist=${SA_ALLOWLIST} \
+--timeout=30

--- a/files/scripts/monitor_sa.py
+++ b/files/scripts/monitor_sa.py
@@ -94,7 +94,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-l",
         "--allowlist",
-        help="The service account allowlist path.",
+        help="The path of the file where the service account allowlist is specified.",
         type=str,
     )
     parser.add_argument(

--- a/files/scripts/monitor_sa.py
+++ b/files/scripts/monitor_sa.py
@@ -30,15 +30,15 @@ logging.basicConfig(
 TIMEOUT_DEFAULT_SECONDS = 30
 
 
-class SANames(NamedTuple):
+class ServiceAccountNames(NamedTuple):
     """Service Account denomination."""
 
     namespace: str
     name: str
 
 
-class SAPatterns(NamedTuple):
-    """Service account shell-style patterns."""
+class ServiceAccountPatterns(NamedTuple):
+    """Service account shell-style patterns for the namespace and the actual resource name."""
 
     namespace: str
     name: str
@@ -51,17 +51,19 @@ def read_configuration_file(file_path: str) -> dict[str, str]:
     return PropertyFile.read(file_path).props
 
 
-def build_patterns(allowlist: list[str]) -> list[SAPatterns]:
+def build_patterns(allowlist: list[str]) -> list[ServiceAccountPatterns]:
     """Build shell-style patterns from allowlist."""
     patterns = []
     for entry in allowlist:
         ns, _, sa = entry.partition(":")
-        patterns.append(SAPatterns(fnmatch.translate(ns), fnmatch.translate(sa)))
+        patterns.append(ServiceAccountPatterns(fnmatch.translate(ns), fnmatch.translate(sa)))
 
     return patterns
 
 
-def is_allowed(service_account: SANames, patterns: list[SAPatterns]) -> bool:
+def is_allowed(
+    service_account: ServiceAccountNames, patterns: list[ServiceAccountPatterns]
+) -> bool:
     """Compare a service account against a list of shell-style patterns."""
     return any(
         re.match(sa_patterns.namespace, service_account.namespace)
@@ -132,7 +134,7 @@ if __name__ == "__main__":
         logger.info(f"Operation: {op}")
         logger.info(f"Service account: {sa_name} --- namespace: {namespace}")
 
-        if not is_allowed(SANames(namespace, sa_name), patterns):
+        if not is_allowed(ServiceAccountNames(namespace, sa_name), patterns):
             logger.info("Not allowed, skipping.")
             continue
 

--- a/files/scripts/monitor_sa.py
+++ b/files/scripts/monitor_sa.py
@@ -5,17 +5,19 @@
 """Routine that updates secrets for Spark service accounts."""
 
 import argparse
+import fnmatch
 import logging
 import os
+import re
 import sys
-from typing import Dict, Optional
+from typing import NamedTuple, cast
+from pathlib import Path
 
-from lightkube.core.client import Client
+from lightkube.core.client import Client, LabelValue
 from lightkube.core.exceptions import ApiError
 from lightkube.resources.core_v1 import Secret, ServiceAccount
-
-from spark8t.literals import HUB_LABEL
 from spark8t.domain import PropertyFile
+from spark8t.literals import HUB_LABEL
 from spark8t.utils import PercentEncodingSerializer
 
 logger = logging.getLogger(__name__)
@@ -27,11 +29,45 @@ logging.basicConfig(
 
 TIMEOUT_DEFAULT_SECONDS = 30
 
-def read_configuration_file(file_path: str) -> Optional[Dict[str, str]]:
+
+class SANames(NamedTuple):
+    """Service Account denomination."""
+
+    namespace: str
+    name: str
+
+
+class SAPatterns(NamedTuple):
+    """Service account shell-style patterns."""
+
+    namespace: str
+    name: str
+
+
+def read_configuration_file(file_path: str) -> dict[str, str]:
     """Read spark configuration file."""
     if not os.path.exists(file_path):
-        return None
+        return {}
     return PropertyFile.read(file_path).props
+
+
+def build_patterns(allowlist: list[str]) -> list[SAPatterns]:
+    """Build shell-style patterns from allowlist."""
+    patterns = []
+    for entry in allowlist:
+        ns, _, sa = entry.partition(":")
+        patterns.append(SAPatterns(fnmatch.translate(ns), fnmatch.translate(sa)))
+
+    return patterns
+
+
+def is_allowed(service_account: SANames, patterns: list[SAPatterns]) -> bool:
+    """Compare a service account against a list of shell-style patterns."""
+    return any(
+        re.match(sa_patterns.namespace, service_account.namespace)
+        and re.match(sa_patterns.name, service_account.name)
+        for sa_patterns in patterns
+    )
 
 
 if __name__ == "__main__":
@@ -54,31 +90,50 @@ if __name__ == "__main__":
         type=str,
     )
     parser.add_argument(
+        "-l",
+        "--allowlist",
+        help="The service account allowlist path.",
+        type=str,
+    )
+    parser.add_argument(
         "-t",
         "--timeout",
         help="The timeout in seconds for the client to close the request to watch the K8s resource.",
         default=TIMEOUT_DEFAULT_SECONDS,
-        type=int
-)
+        type=int,
+    )
     args = parser.parse_args()
     logger.info("Start process that update service account secrets.")
     client = Client(field_manager=args.app_name)  # type: ignore
-    label_selector = {"app.kubernetes.io/managed-by": "spark8t"}
+    label_selector: dict[str, LabelValue] = {"app.kubernetes.io/managed-by": "spark8t"}
+    allowlist_path = Path(args.allowlist)
+    try:
+        with allowlist_path.open("r") as f:
+            allowlist = [entry.strip() for entry in f.read().splitlines()]
+    except FileNotFoundError:
+        logger.error("Could not find allowlist.")
+        allowlist = []
+
+    patterns = build_patterns(allowlist)
 
     for op, sa in client.watch(
-        ServiceAccount, 
-        namespace="*", 
-        labels=label_selector, 
-
+        ServiceAccount,
+        namespace="*",
+        labels=label_selector,
         # This timeout is needed for the client to not hang up indefinitely when the K8s server
         # stops responding to the watch request due to inactivity for long period of time.
         # https://github.com/canonical/spark-k8s-bundle/issues/72
-        server_timeout=TIMEOUT_DEFAULT_SECONDS
+        server_timeout=TIMEOUT_DEFAULT_SECONDS,
     ):
-        sa_name = sa.metadata.name
-        namespace = sa.metadata.namespace
+        sa_name = cast(str, getattr(sa.metadata, "name"))
+        namespace = cast(str, getattr(sa.metadata, "namespace"))
         logger.info(f"Operation: {op}")
         logger.info(f"Service account: {sa_name} --- namespace: {namespace}")
+
+        if not is_allowed(SANames(namespace, sa_name), patterns):
+            logger.info("Not allowed, skipping.")
+            continue
+
         # skip in case of deletion or operation that do not need secret update.
         logger.info(f"Config file: {args.config}")
         options = {
@@ -111,7 +166,7 @@ if __name__ == "__main__":
                 "metadata": {
                     "name": secret_name,
                     "namespace": namespace,
-                    "labels": {"app.kubernetes.io/managed-by": "integration-hub"}
+                    "labels": {"app.kubernetes.io/managed-by": "integration-hub"},
                 },
                 "stringData": options if options else {},
             }

--- a/files/scripts/monitor_sa.py
+++ b/files/scripts/monitor_sa.py
@@ -10,8 +10,8 @@ import logging
 import os
 import re
 import sys
-from typing import NamedTuple, cast
 from pathlib import Path
+from typing import NamedTuple, cast
 
 from lightkube.core.client import Client, LabelValue
 from lightkube.core.exceptions import ApiError
@@ -110,8 +110,10 @@ if __name__ == "__main__":
     try:
         with allowlist_path.open("r") as f:
             allowlist = [entry.strip() for entry in f.read().splitlines()]
-    except FileNotFoundError:
-        logger.error("Could not find allowlist.")
+    except (FileNotFoundError, IsADirectoryError):
+        # IsADirectoryError happens when the env var is not defined:
+        # Path("") is Path(".")
+        logger.warning("Could not find allowlist, proceeding without it.")
         allowlist = []
 
     patterns = build_patterns(allowlist)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[tool.ruff]
+line-length = 99
+extend-exclude = ["__pycache__", "*.egg_info"]
+target-version = "py310"
+src = ["files/scripts", "tests"]
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
+  "D203",
+  "D204",
+  "D213",
+  "D215",
+  "D400",
+  "D401",
+  "D404",
+  "D406",
+  "D407",
+  "D408",
+  "D409",
+  "D413",
+]
+ignore = ["E501", "D107"]
+per-file-ignores = { "tests/*" = ["D100", "D101", "D102", "D103", "D104", "E999"] }
+mccabe.max-complexity = 10

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -28,6 +28,7 @@ services:
     on-failure: restart
     environment:
       SPARK_PROPERTIES_FILE: /etc/hub/conf/spark-defaults.conf
+      SA_ALLOWLIST: /etc/hub/conf/allowlist
 
 
 parts:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -15,7 +15,6 @@ platforms:
 run_user: _daemon_
 
 environment:
-  JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
   PYTHONPATH: /opt/spark/python:/opt/spark8t/python/dist:/usr/lib/python3.10/site-packages
   PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
@@ -86,7 +85,6 @@ parts:
     after: [ hub-files ]
     overlay-packages:
       - python3
-      - openjdk-17-jre-headless
 
     override-prime: |
       # Please refer to https://discourse.ubuntu.com/t/unifying-user-identity-across-snaps-and-rocks/36469

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,0 +1,37 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+import pytest
+
+from monitor_sa import SANames, build_patterns, is_allowed
+
+
+@pytest.mark.parametrize(
+    ["raw_service_account", "allowlist", "expected"],
+    [
+        # Explicit listing
+        ("foo:bar", ["foo:bar"], True),
+        ("buzz:bizz", ["foo:bar", "buzz:bizz"], True),
+        ("foo:bar", ["foo:barracuda"], False),
+        # Wildcards
+        ("foo:bar", ["foo:*"], True),
+        ("foo:bar", ["*:bar"], True),
+        ("foo:bar", ["*:barracuda"], False),
+        # Prefixes/suffixes
+        ("foo:barracuda", ["foo:bar*"], True),
+        ("foo-fighters:barracuda", ["foo-*:bar*"], True),
+        ("foo:barracuda", ["*:*cuda"], True),
+        # Any
+        ("foo:bar", ["*:*"], True),
+    ],
+)
+def test_is_allowed(raw_service_account: str, allowlist: list[str], expected: bool) -> None:
+    # Given
+    patterns = build_patterns(allowlist)
+    ns, _, sa = raw_service_account.partition(":")
+    service_account = SANames(ns, sa)
+
+    # When
+    result = is_allowed(service_account, patterns)
+
+    # Then
+    assert result is expected

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 import pytest
 
-from monitor_sa import SANames, build_patterns, is_allowed
+from monitor_sa import ServiceAccountNames, build_patterns, is_allowed
 
 
 @pytest.mark.parametrize(
@@ -28,7 +28,7 @@ def test_is_allowed(raw_service_account: str, allowlist: list[str], expected: bo
     # Given
     patterns = build_patterns(allowlist)
     ns, _, sa = raw_service_account.partition(":")
-    service_account = SANames(ns, sa)
+    service_account = ServiceAccountNames(ns, sa)
 
     # When
     result = is_allowed(service_account, patterns)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,41 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+[tox]
+no_package = True
+skip_missing_interpreters = True
+env_list = lint, unit
+
+[vars]
+src_path = {tox_root}/files/scripts
+tests_path = {tox_root}/tests
+all_path = {[vars]src_path} {[vars]tests_path}
+
+[testenv]
+allowlist_externals =
+    /bin/bash
+
+set_env =
+    PYTHONPATH = {[vars]src_path}
+
+[testenv:format]
+description = Apply coding style standards to code
+commands =
+    pip install ruff
+    ruff format --config pyproject.toml {[vars]all_path}
+
+[testenv:lint]
+description = Check code against coding style standards
+commands =
+    pip install ruff mypy
+    ruff format --config pyproject.toml {[vars]all_path}
+    ruff check --config pyproject.toml --fix {[vars]all_path}
+
+	pip install lightkube spark8t
+    mypy {[vars]src_path} --ignore-missing
+
+[testenv:unit]
+description = Run unit tests
+commands =
+	pip install pytest lightkube spark8t
+	python -m pytest {[vars]tests_path}


### PR DESCRIPTION
## Changes

- Removed the JRE from the Rock: from ~150MB down to ~70!
- Implemented the filtering logic to monitor service accounts based on an allowlist of patterns.
- Added some quality of code tooling: format/lint/tests on CI

### Shell-style patterns

I choose to implement the allow list using shell-style "glob patterns" instead of regular expressions, so that the user experience is more streamlined and less error-prone.
- `foo:bar` will only match the `bar` username in the "foo" namespace
- `foo:bar*` will match all usernames in the `foo` namespace starting with `bar`, such as `bar`, `barbecue`, `barracuda`
- `foo:*` will match all usernames in the `foo` namespace

There are more capabilities to this feature, like `foo:bar|buzz` meaning allowing both the `bar` and `buzz` service account in the `foo` namespace, but it's up to the charm to allow that or not by blocking a configuration option value or a requested service account we don't want.
I would be personally more in favor of restricting the syntax as much as possible on the charm side by removing all special chars but `*`

See the rock in action here: https://github.com/canonical/spark-integration-hub-k8s-operator/pull/120