### PR TITLE
[PRA-73] Bump spark8t to 1.3.0

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -42,7 +42,7 @@ parts:
       - python3-pip
     overlay-script: |
       mkdir -p $CRAFT_PART_INSTALL/opt/spark8t/python/dist
-      pip install --target=${CRAFT_PART_INSTALL}/opt/spark8t/python/dist spark8t==1.1.0
+      pip install --target=${CRAFT_PART_INSTALL}/opt/spark8t/python/dist spark8t==1.3.0
       rm usr/bin/pip*
     stage:
       - opt/spark8t/python/dist


### PR DESCRIPTION
This PR bumps the internal spark8t library used by the integration hub rock to 1.3.0.

This is needed to restore the compatibility of the charm with recent juju releases.

I was able to locally confirm that a Hub charm built for juju 3.6.14 with an OCI resource such as defined by this PR's rockcraft file (https://hub.docker.com/repository/docker/batalex/spark-integration-hub/tags) was able to properly integrate with Kyuubi instead of crashing while applying the managed-by label.